### PR TITLE
Fix the case with unclosed "<br>" tag

### DIFF
--- a/google_translate_diff.gemspec
+++ b/google_translate_diff.gemspec
@@ -42,6 +42,7 @@ between revisions of long texts.
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "pry-byebug"
 
   spec.add_dependency "google-cloud-translate"
   spec.add_dependency "ox"

--- a/lib/google_translate_diff/tokenizer.rb
+++ b/lib/google_translate_diff/tokenizer.rb
@@ -1,7 +1,9 @@
 class GoogleTranslateDiff::Tokenizer < ::Ox::Sax
+  attr_reader :source
+
   def initialize(source)
     @pos = nil
-    @source = source
+    @source = source.gsub("<br>", "<br />")
     @tokens = []
     @context = []
     @sequence = []
@@ -94,7 +96,7 @@ class GoogleTranslateDiff::Tokenizer < ::Ox::Sax
     def tokenize(value)
       return [] if value.nil?
       tokenizer = new(value).tap do |h|
-        Ox.sax_parse(h, StringIO.new(value), HTML_OPTIONS)
+        Ox.sax_parse(h, StringIO.new(h.source), HTML_OPTIONS)
       end
       puts tokenizer.tokens.inspect
       tokenizer.tokens

--- a/spec/google_translate_diff/tokenizer_spec.rb
+++ b/spec/google_translate_diff/tokenizer_spec.rb
@@ -75,6 +75,22 @@ RSpec.describe GoogleTranslateDiff::Tokenizer do
     it_behaves_like "tokenizer"
   end
 
+  context "with <br> tag before closing tag" do
+    let(:source) do
+      "<font size='3'>Смеркалось.<br></font>"
+    end
+
+    let(:tokens) do
+      [
+        ["<font size='3'>", :markup],
+        ["Смеркалось.", :text],
+        ["<br /></font>", :markup]
+      ]
+    end
+
+    it_behaves_like "tokenizer"
+  end
+
   context "sentences" do
     let(:source) do
       "! Киловольт. <span>Смеркалось.    Ворчало. Кричало.</span>"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require "bundler/setup"
 require "simplecov"
+require "pry"
 
 SimpleCov.start
 


### PR DESCRIPTION
Before the fix tokenization were broken because `Ox.parse` treated `<br>` as `<br></br>` which broke the whole sequece of `@pos`-itions in the tokenizer.

I did preprocessing of text-to-be-tokenized by changing all `<br>` to `<br />` and then used that preprocessed value in tokenization. It seems to work now (c).