### PR TITLE
Hack tokenization of ?-started tags like <?xml:namespace...>

### DIFF
--- a/spec/google_translate_diff/tokenizer_spec.rb
+++ b/spec/google_translate_diff/tokenizer_spec.rb
@@ -128,4 +128,22 @@ RSpec.describe GoogleTranslateDiff::Tokenizer do
 
     it_behaves_like "tokenizer"
   end
+
+  context "with <?xml:...> tag" do
+    let(:source) do
+      "Hey!<br />Look!" \
+      "<?xml:namespace ns=\"urn:office\" />"
+    end
+
+    let(:tokens) do
+      [
+        ["Hey!", :text],
+        ["<br />", :markup],
+        ["Look!", :text],
+        ["<?xml:namespace ns=\"urn:office\" />", :markup]
+      ]
+    end
+
+    it_behaves_like "tokenizer"
+  end
 end


### PR DESCRIPTION
@gzigzigzeo  please, look at this hack.

I cannot understand why Ox doesn't do this job properly (it treats `<?xml:namespace ...>`-like tags as plain texts and breaks the whole tokenization.
