### PR TITLE
Fix tokenizer for the case of nested spans inside "notranslate"

### DIFF
--- a/spec/google_translate_diff/tokenizer_spec.rb
+++ b/spec/google_translate_diff/tokenizer_spec.rb
@@ -113,6 +113,38 @@ RSpec.describe GoogleTranslateDiff::Tokenizer do
     it_behaves_like "tokenizer"
   end
 
+  context "notranslate inside another span" do
+    let(:source) do
+      "<span><span class='notranslate'>foo<span>bar<br></span>baz</span></span>"
+    end
+
+    let(:tokens) do
+      [
+        ["<span>", :markup],
+        ["<span class='notranslate'>foo<span>bar<br></span>baz</span>", :text],
+        ["</span>", :markup]
+      ]
+    end
+
+    it_behaves_like "tokenizer"
+  end
+
+  context "notranslate inside another notranslate" do
+    let(:source) do
+      "<span class='notranslate'>foo" \
+      "<span class='notranslate'>bar</span>baz" \
+      "</span>"
+    end
+
+    let(:tokens) do
+      [
+        [source, :text]
+      ]
+    end
+
+    it_behaves_like "tokenizer"
+  end
+
   context "with <br> tag before closing tag" do
     let(:source) do
       "<font size='3'>Смеркалось.<br></font>"


### PR DESCRIPTION
The problem occures when in the source markup there're structures like:

```ruby
source = <<~HTML
<span>
  <span class="notranslate">  </span>Payment
</span>
HTML

target = GoogleTranslateDiff.translate(source, from: "en", to: "it")
puts target
# <span>
#   <span class="notranslate">  </span> Pagamento
```

In this case we lost the outer </span> and broke the markup.

The cause is that we make no difference between `</span>`,
whether they close the very 'notranslate' block, or another span
that was opened _inside_ the block.

As a solution I draw the distinction between spans:
- span opened _outside_ of the notranslate (typed as :markup)
- span that openes notranslate block (typed as :notranslate as before)
- span that opened _inside_ the block (types as :span)

For tag endings `</span>` I analyze the previous stream to decide
what span we close. And type them as:
- :markup when we are _outside_ of notranslate block
- :end_span when we close the span _inside_ the block
- :end_notranslate when we close the very block (all inner spans are closed)

I also draw the difference between "notranslate spans" that are
inside another notranslate block. Instead of opening a new block
they are treated just like the regular `span`-s.