### PR TITLE
gemspec: drop unused directives

### DIFF
--- a/google_translate_diff.gemspec
+++ b/google_translate_diff.gemspec
@@ -32,8 +32,6 @@ between revisions of long texts.
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.14"


### PR DESCRIPTION
This PR makes the gemspec shorter by not mentioning any executables, this gem exposes none of those.